### PR TITLE
Update scala version from 2.13.5 -> 2.13.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val `pluto_versions_manager` = (project in file("."))
 
 resolvers += "Akka Snapshot Repository" at "https://repo.akka.io/snapshots/"
       
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.9"
 
 libraryDependencies ++= Seq( specs2 % Test , guice )
 


### PR DESCRIPTION
## What does this change?

Updates Scala version to 2.13.9 as v2.13.5 has a known critical vulnerability. 
