### PR TITLE
Use the GITHUB_TOKEN Secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v2
@@ -54,7 +55,7 @@ jobs:
       - run: if [ -d "junit-tests" ]; then mkdir junit-tests; fi
         name: Prepare test outputs location
 
-      - run: "echo -e \"\n//npm.pkg.github.com/:_authToken=${{secrets.ACTION}}\" >> .npmrc"
+      - run: "echo -e \"\n//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}\" >> .npmrc"
         working-directory: frontend
 
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## What does this change?

Moves the software back to using the GITHUB_TOKEN secret during building. 

## How can we measure success?

The software builds correctly using the GITHUB_TOKEN secret and no longer relies on Dave Allison's GitHub account.
